### PR TITLE
[ESP32-0] Add prepare-commit-msg hook for conventional commit automation

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================
+# Git Hook: prepare-commit-msg
+# Author: Bruno Santos
+# Description: Prompts for task ID and type, then generates a
+#              conventional commit message with description template.
+# =============================================================
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+if [ -n "$COMMIT_SOURCE" ]; then
+    exit 0
+fi
+
+TYPES=("feat" "fix" "refactor" "docs" "test" "chore" "style")
+
+echo ""
+echo "┌─────────────────────────────────────────┐"
+echo "│         ESP32 Commit Helper             │"
+echo "└─────────────────────────────────────────┘"
+echo ""
+
+read -rp "  Task ID (e.g. ESP32-1) or ENTER to skip: " TASK_ID
+
+echo ""
+echo "  Commit type:"
+for i in "${!TYPES[@]}"; do
+    printf "    [%d] %s\n" "$((i+1))" "${TYPES[$i]}"
+done
+echo ""
+read -rp "  Choose [1-${#TYPES[@]}] (default: 1): " TYPE_CHOICE
+TYPE_CHOICE=${TYPE_CHOICE:-1}
+COMMIT_TYPE="${TYPES[$((TYPE_CHOICE-1))]}"
+
+echo ""
+read -rp "  Scope (e.g. esp32, wifi, sensor) or ENTER to skip: " SCOPE
+
+echo ""
+read -rp "  Short description: " SHORT_DESC
+
+if [ -n "$SCOPE" ]; then
+    TITLE="${COMMIT_TYPE}(${SCOPE}): ${SHORT_DESC}"
+else
+    TITLE="${COMMIT_TYPE}: ${SHORT_DESC}"
+fi
+
+{
+    echo "$TITLE"
+    echo ""
+    echo "- "
+    echo "- "
+    echo "- "
+    echo ""
+    if [ -n "$TASK_ID" ]; then
+        echo "Refs: $TASK_ID"
+    fi
+} > "$COMMIT_MSG_FILE"
+
+echo ""
+echo "  ✔ Commit message generated. Complete the bullet points in your editor."
+echo ""


### PR DESCRIPTION
## Summary
Adds a Git hook that interactively guides the developer through writing
conventional commit messages, ensuring consistency across all commits
in the repository.

## Changes
- Add `.githooks/prepare-commit-msg` shell script with interactive CLI prompt
- Hook triggers automatically on `git commit` via Git Bash
- Generates commit title following Conventional Commits spec
- Appends `Refs: TASK-ID` footer automatically

## How to Install After Cloning
```bash
cp .githooks/prepare-commit-msg .git/hooks/prepare-commit-msg
chmod +x .git/hooks/prepare-commit-msg
```

## Testing
- [x] Hook triggers on `git commit`
- [x] Prompts for Task ID, type, scope and short description
- [x] Generates correct commit title format
- [x] Opens editor with bullet point template
- [x] Appends Refs footer when Task ID is provided

## Notes
> `.git/hooks/` is not tracked by Git — `.githooks/` is the versioned
> source of truth. Always copy from there after cloning.

## Refs
Closes ESP32-0